### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,14 @@ I optimized for images with dark backgrounds and used 0's and 1's for the charac
 
 1. Install go
 2. Set your $GOPATH
-3. Install github.com/nfnt/
-4. Build ansize
+3. go get github.com/jhchen/ansize
 
 On a Mac with Homebrew the commands are
 
     brew install go
     mkdir /usr/local/lib/go
     export GOPATH=/usr/local/lib/go
-    go get github.com/nfnt/resize
-    go build ansize.go
+    go get github.com/jhchen/ansize
 
 On ArchLinux, you can simply install the package [`ansize-git`](https://aur.archlinux.org/packages/ansize-git/).
 


### PR DESCRIPTION
go get will fetch the dependencies of the package it is trying to build so there isn't a need for an intermediate go get.
