### PR TITLE
Image proportion fix

### DIFF
--- a/ansize.go
+++ b/ansize.go
@@ -41,7 +41,9 @@ func toAnsiSpace(val uint32) (int) {
 }
 
 func writeAnsiImage(img image.Image, file *os.File, width int) {
-	m := resize.Resize(uint(width), uint(float32(width) * PROPORTION), img, resize.Lanczos3)
+	imgW, imgH := float32(img.Bounds().Dx()), float32(img.Bounds().Dy())
+	height := float32(width) * (imgH / imgW) * PROPORTION
+	m := resize.Resize(uint(width), uint(height), img, resize.Lanczos3)
 	var current, previous string
 	bounds := m.Bounds()
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {


### PR DESCRIPTION
This is a proposed fix to keep the output height proportional to the original dimensions of the input image. (Prevents rectangular images from stretching / squashing)

Test input:
![pikachu_wide](https://user-images.githubusercontent.com/3377325/219469778-6f2cd9ca-d078-424b-8377-5b6146fd1806.png)

Before:
![ansize_before](https://user-images.githubusercontent.com/3377325/219469866-7ee5a0e4-0b7c-4294-a9d8-f1e0155825e3.png)

After:
![ansize_after](https://user-images.githubusercontent.com/3377325/219470230-fed54aa0-78e6-468c-96b6-95ffb3505262.png)
